### PR TITLE
Added Support for Saving and Loading Models

### DIFF
--- a/example/save_load_model_example.dart
+++ b/example/save_load_model_example.dart
@@ -1,0 +1,80 @@
+import 'package:synadart/src/layers/core/dense.dart';
+import 'package:synadart/synadart.dart';
+
+const modelPath = r'C:\Users\myName\Documents\myModel.json';
+
+final trainingData = [
+  '111101101101111'.split('').map(double.parse).toList(),
+  '001001001001001'.split('').map(double.parse).toList(),
+  '111001111100111'.split('').map(double.parse).toList(),
+  '111001111001111'.split('').map(double.parse).toList(),
+  '101101111001001'.split('').map(double.parse).toList(),
+  '111100111001111'.split('').map(double.parse).toList(), // 5
+  '111100111101111'.split('').map(double.parse).toList(),
+  '111001001001001'.split('').map(double.parse).toList(),
+  '111101111101111'.split('').map(double.parse).toList(),
+  '111101111001111'.split('').map(double.parse).toList(),
+];
+
+void main() {
+  _train().then((value) => _load());
+}
+
+Future<void> _load() async {
+  // Load the model from the file.
+  final network = await Sequential.loadModel(modelPath);
+
+  // The number 5 itself.
+  final numberFive = trainingData[5];
+
+  // Use the model.
+  final result = network.process(numberFive);
+  print('Confidence in recognising a 5: $result');
+}
+
+Future<void> _train() async {
+  final network = Sequential(
+    learningRate: 0.2,
+    layers: [
+      Dense(
+        size: 15,
+        activation: ActivationAlgorithm.sigmoid,
+      ),
+      Dense(
+        size: 5,
+        activation: ActivationAlgorithm.sigmoid,
+      ),
+      Dense(
+        size: 1,
+        activation: ActivationAlgorithm.sigmoid,
+      )
+    ],
+  );
+
+  // We are expecting to get the number '5'.
+  final expected = [
+    [0.01], // 0
+    [0.01], // 1
+    [0.01], // 2
+    [0.01], // 3
+    [0.01], // 4
+    [0.99], // 5
+    [0.01], // 6
+    [0.01], // 7
+    [0.01], // 8
+    [0.01], // 9
+  ];
+
+  // The number 5 itself.
+  final numberFive = trainingData[5];
+
+  // Train the network using the training and expected data.
+  network.train(inputs: trainingData, expected: expected, iterations: 20000);
+
+  final result = network.process(numberFive);
+  print('Confidence in recognising a 5: $result');
+
+  // Save the model to the file.
+  await network.saveModel(modelPath);
+  print('Model saved to $modelPath');
+}

--- a/lib/src/networks/sequential.dart
+++ b/lib/src/networks/sequential.dart
@@ -1,12 +1,72 @@
+import 'dart:convert';
+
+import 'package:synadart/src/layers/core/dense.dart';
 import 'package:synadart/src/networks/network.dart';
 import 'package:synadart/src/networks/training/backpropagation.dart';
+import 'package:synadart/src/neurons/neuron.dart';
+import 'package:synadart/src/utils/save_load.dart';
+import 'package:synadart/synadart.dart';
 
 /// A `Network` model in which every `Layer` has one input and one output
 /// tensor.
 class Sequential extends Network with Backpropagation {
+  final String _activationField = 'activation';
+  final String _neuronsField = 'neurons';
+
   /// Creates a `Sequential` model network.
   Sequential({
     required super.learningRate,
     super.layers,
   });
+
+  /// Load the model from a JSON file.
+  static Future<Sequential> loadModel(String absolutePath) async {
+    final jsonData = await readFromFile(absolutePath);
+    return Sequential._loadModel(jsonData);
+  }
+
+  /// Loads a model from a JSON string.
+  Sequential._loadModel(String rawNeuronData)
+      : super(
+          layers: [],
+          learningRate: 0,
+        ) {
+    final data = jsonDecode(rawNeuronData) as List;
+    for (final layer in data) {
+      final activationIndex = layer[_activationField] as int;
+      final neuronsInfo = List<RawNeuron>.from(layer[_neuronsField] as List);
+
+      final activation = ActivationAlgorithm.values[activationIndex];
+      final neurons = neuronsInfo.map(Neuron.fromJson);
+
+      final denseLayer = Dense(
+        size: neurons.length,
+        activation: activation,
+      )
+        // Only the firt layer is an input layer
+        ..isInput = layers.isEmpty
+        ..neurons.addAll(neurons);
+
+      layers.add(denseLayer);
+    }
+  }
+
+  /// Save the model to a JSON file.
+  Future<void> saveModel(String path) async {
+    // Save weights and biases for each neuron in each layer
+    final data = <Map<String, dynamic>>[];
+    for (final layer in layers) {
+      final neuronData = <Map>[];
+      for (final neuron in layer.neurons) {
+        neuronData.add(neuron.toJson());
+      }
+      final layerData = <String, dynamic>{
+        _activationField: layer.activation.index,
+        _neuronsField: neuronData,
+      };
+      data.add(layerData);
+    }
+    final jsonData = jsonEncode(data);
+    await writeToFile(path, jsonData);
+  }
 }

--- a/lib/src/neurons/neuron.dart
+++ b/lib/src/neurons/neuron.dart
@@ -121,7 +121,7 @@ class Neuron {
     learningRate = json[_fieldLearningRate] as double;
 
     final activationIndex = json[_fieldActivationAlgorithm] as int;
-    final activationAlgorithm = ActivationAlgorithm.values[activationIndex];
+    activationAlgorithm = ActivationAlgorithm.values[activationIndex];
     activation = resolveActivationAlgorithm(activationAlgorithm);
     activationPrime = resolveActivationDerivative(activationAlgorithm);
   }

--- a/lib/src/utils/save_load.dart
+++ b/lib/src/utils/save_load.dart
@@ -1,0 +1,21 @@
+import 'dart:io';
+
+/// Raw representation of a single `Neuron` as a Json Map.
+typedef RawNeuron = Map<String, dynamic>;
+
+/// Writes a string to a file.
+Future<void> writeToFile(String absolutePath, String data) async {
+  final file = File(absolutePath);
+  await file.writeAsString(data);
+}
+
+/// Reads a string from a file.
+Future<String> readFromFile(String absolutePath) async {
+  try {
+    final file = File(absolutePath);
+    return await file.readAsString();
+  } on Exception catch (e) {
+    print('Error reading file: $e');
+    rethrow;
+  }
+}


### PR DESCRIPTION
Added 2 methods:
`network.saveModel(path)`
and
`Sequential.loadModel(path)`

Now you have the chance to save a trained model to a json file, and then import that trained model when needed